### PR TITLE
Add test for int and float arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ public function setTitle(?string $title): void
     $this->title = $title;
 }
 
-public function getTitle(string $title): void
+public function getTitle(): void
 {
     $this->title = $title;
 }
@@ -34,7 +34,7 @@ public function testSetTitle(): void
 }
 ```
 
-But as `?string` can be seen as an union type of `string|null` the testcase for `null` is missing:
+But as `?string` can be seen as an union type of `string|null` the testcase for `null` type is missing:
 
 ```php
 public function testSetTitleNull(): void
@@ -45,7 +45,7 @@ public function testSetTitleNull(): void
 }
 ```
 
-The project target is to already generate also the boilderplate for that test case.
+The project target is to already generate also the boilerplate for that test case.
 
 ## Installation
 

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -30,7 +30,7 @@ class AbstractTestCase extends TestCase
 
         foreach ($finder as $file) {
             if ($file instanceof \SplFileInfo) {
-                yield [$file];
+                yield \str_replace(\getcwd() . '/', '', $file->getPathname()) => [$file];
             }
         }
     }

--- a/tests/Model/SetGet/Fixture/model_with_set_get_float.php
+++ b/tests/Model/SetGet/Fixture/model_with_set_get_float.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App;
+
+class ModelWithSetGetFloat
+{
+    private float $number = 0.0;
+
+    public function setNumber(float $number): void
+    {
+        $this->number = $number;
+    }
+
+    public function getNumber(): float
+    {
+        return $this->number;
+    }
+}
+
+?>
+---
+<?php
+
+namespace App\Tests\Unit;
+
+use App\ModelWithSetGetFloat;
+use PHPUnit\Framework\TestCase;
+
+class ModelWithSetGetFloatTest extends TestCase
+{
+    public function testSetGetNumber(): void
+    {
+        $model = $this->createInstance();
+        $this->assertNull($model->getNumber());
+        $model->setNumber(1.01);
+        $this->assertSame(1.01, $model->getNumber());
+        $this->markAsRisky();
+    }
+
+    public function createInstance(): ModelWithSetGetFloat
+    {
+        return new ModelWithSetGetFloat();
+    }
+}

--- a/tests/Model/SetGet/Fixture/model_with_set_get_int.php
+++ b/tests/Model/SetGet/Fixture/model_with_set_get_int.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App;
+
+class ModelWithSetGetInt
+{
+    private int $title = 0;
+
+    public function setTitle(int $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): int
+    {
+        return $this->title;
+    }
+}
+
+?>
+---
+<?php
+
+namespace App\Tests\Unit;
+
+use App\ModelWithSetGetInt;
+use PHPUnit\Framework\TestCase;
+
+class ModelWithSetGetIntTest extends TestCase
+{
+    public function testSetGetTitle(): void
+    {
+        $model = $this->createInstance();
+        $this->assertNull($model->getTitle());
+        $model->setTitle(1);
+        $this->assertSame(1, $model->getTitle());
+        $this->markAsRisky();
+    }
+
+    public function createInstance(): ModelWithSetGetInt
+    {
+        return new ModelWithSetGetInt();
+    }
+}


### PR DESCRIPTION
Add test cases for argument resolver creating also int and float types.
Also make the test runs more user friendly by output the file path of the tested file.