### PR TITLE
Add setter getter support for objects

### DIFF
--- a/src/Application/Generator/ArgumentGenerator.php
+++ b/src/Application/Generator/ArgumentGenerator.php
@@ -99,7 +99,7 @@ class ArgumentGenerator
                 $attribute = $dateTimeAttributes[$attributeName];
             }
 
-            $attributes[] = $attribute;
+            $attributes[$attributeName] = $attribute;
         }
 
         return $attributes;

--- a/src/Application/Writer/WriteVisitor.php
+++ b/src/Application/Writer/WriteVisitor.php
@@ -75,7 +75,7 @@ final class WriteVisitor extends NodeVisitorAbstract
 
                 $setterArgumentsList = [];
                 $setterArgumentsList[] = $this->argumentGenerator->generateArguments($testMethodConfig['options']['setMethodAttributes'], 'minimal');
-                if (($setterArgumentsList[0][array_key_first($setterArgumentsList[0])] ?? null) === null) {
+                if (($setterArgumentsList[0][\array_key_first($setterArgumentsList[0])] ?? null) === null) {
                     $setterArgumentsList[] = $this->argumentGenerator->generateArguments($testMethodConfig['options']['setMethodAttributes'], 'full');
                     $setterArgumentsList = \array_reverse($setterArgumentsList);
                 }
@@ -94,7 +94,7 @@ final class WriteVisitor extends NodeVisitorAbstract
                         }
                     }
 
-                    $setterArguments = array_values($setterArguments);
+                    $setterArguments = \array_values($setterArguments);
 
                     $setterMethod = $factory->methodCall(
                         $factory->var('model'),

--- a/src/Application/Writer/WriteVisitor.php
+++ b/src/Application/Writer/WriteVisitor.php
@@ -75,12 +75,27 @@ final class WriteVisitor extends NodeVisitorAbstract
 
                 $setterArgumentsList = [];
                 $setterArgumentsList[] = $this->argumentGenerator->generateArguments($testMethodConfig['options']['setMethodAttributes'], 'minimal');
-                if (($setterArgumentsList[0][0] ?? null) === null) {
+                if (($setterArgumentsList[0][array_key_first($setterArgumentsList[0])] ?? null) === null) {
                     $setterArgumentsList[] = $this->argumentGenerator->generateArguments($testMethodConfig['options']['setMethodAttributes'], 'full');
                     $setterArgumentsList = \array_reverse($setterArgumentsList);
                 }
 
                 foreach ($setterArgumentsList as $setterArguments) {
+                    foreach ($setterArguments as $attributeName => $setterArgument) {
+                        if ($setterArgument instanceof Node\Expr\New_) {
+                            $method->addStmt(
+                                new Node\Expr\Assign(
+                                    $factory->var($attributeName),
+                                    $setterArgument
+                                )
+                            );
+
+                            $setterArguments[$attributeName] = $factory->var($attributeName);
+                        }
+                    }
+
+                    $setterArguments = array_values($setterArguments);
+
                     $setterMethod = $factory->methodCall(
                         $factory->var('model'),
                         $testMethodConfig['options']['setMethod'],

--- a/tests/Model/SetGet/Fixture/model_with_set_get_datetime.php
+++ b/tests/Model/SetGet/Fixture/model_with_set_get_datetime.php
@@ -33,8 +33,9 @@ class ModelWithSetGetBirthdayTest extends TestCase
     {
         $model = $this->createInstance();
         $this->assertNull($model->getBirthday());
-        $model->setBirthday(new DateTime('2022-01-01'));
-        $this->assertSame(new DateTime('2022-01-01'), $model->getBirthday());
+        $birthday = new DateTime('2022-01-01');
+        $model->setBirthday($birthday);
+        $this->assertSame($birthday, $model->getBirthday());
         $this->markAsRisky();
     }
 

--- a/tests/Model/SetGet/Fixture/model_with_set_get_datetime_immutable.php
+++ b/tests/Model/SetGet/Fixture/model_with_set_get_datetime_immutable.php
@@ -33,8 +33,9 @@ class ModelWithSetGetBirthdayTest extends TestCase
     {
         $model = $this->createInstance();
         $this->assertNull($model->getBirthday());
-        $model->setBirthday(new DateTimeImmutable('2022-01-01'));
-        $this->assertSame(new DateTimeImmutable('2022-01-01'), $model->getBirthday());
+        $birthday = new DateTimeImmutable('2022-01-01');
+        $model->setBirthday($birthday);
+        $this->assertSame($birthday, $model->getBirthday());
         $this->markAsRisky();
     }
 

--- a/tests/Model/SetGet/Fixture/model_with_set_get_datetime_immutable_nullable.php
+++ b/tests/Model/SetGet/Fixture/model_with_set_get_datetime_immutable_nullable.php
@@ -33,8 +33,9 @@ class ModelWithSetGetBirthdayTest extends TestCase
     {
         $model = $this->createInstance();
         $this->assertNull($model->getBirthday());
-        $model->setBirthday(new DateTimeImmutable('2022-01-01'));
-        $this->assertSame(new DateTimeImmutable('2022-01-01'), $model->getBirthday());
+        $birthday = new DateTimeImmutable('2022-01-01');
+        $model->setBirthday($birthday);
+        $this->assertSame($birthday, $model->getBirthday());
         $model->setBirthday(null);
         $this->assertNull($model->getBirthday());
         $this->markAsRisky();

--- a/tests/Model/SetGet/Fixture/model_with_set_get_datetime_nullable.php
+++ b/tests/Model/SetGet/Fixture/model_with_set_get_datetime_nullable.php
@@ -33,8 +33,9 @@ class ModelWithSetGetBirthdayTest extends TestCase
     {
         $model = $this->createInstance();
         $this->assertNull($model->getBirthday());
-        $model->setBirthday(new DateTime('2022-01-01'));
-        $this->assertSame(new DateTime('2022-01-01'), $model->getBirthday());
+        $birthday = new DateTime('2022-01-01');
+        $model->setBirthday($birthday);
+        $this->assertSame($birthday, $model->getBirthday());
         $model->setBirthday(null);
         $this->assertNull($model->getBirthday());
         $this->markAsRisky();


### PR DESCRIPTION
This will create a variable for setter getter tests when an object is used e.g.:

```php
        $birthday = new DateTimeImmutable('2022-01-01');
        $model->setBirthday($birthday);
        $this->assertSame($birthday, $model->getBirthday());
```