### PR TITLE
Add basic getter test implementation

### DIFF
--- a/src/Application/Generator/ArgumentGenerator.php
+++ b/src/Application/Generator/ArgumentGenerator.php
@@ -15,6 +15,7 @@ namespace Schranz\TestGenerator\Application\Generator;
 
 use PhpParser\BuilderFactory;
 use PhpParser\Node\ComplexType;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
@@ -32,7 +33,7 @@ class ArgumentGenerator
      *     returnType: array<string, null|Identifier|Name|ComplexType>,
      * } $methodAttributes
      *
-     * @return mixed[]
+     * @return Expr[]
      */
     public function generateArguments(array $methodAttributes, string $behaviour = 'minimal'): array
     {
@@ -44,7 +45,7 @@ class ArgumentGenerator
             $typeName = null;
 
             if ($attributeConfig instanceof NullableType && 'minimal' === $behaviour) {
-                $attributes[] = null;
+                $attributes[$attributeName] = $factory->val(null);
 
                 continue;
             } elseif ($attributeConfig instanceof NullableType) {
@@ -53,10 +54,12 @@ class ArgumentGenerator
                 $typeName = $attributeConfig->name;
             } elseif ($attributeConfig instanceof FullyQualified) {
                 $typeName = $attributeConfig->toString();
+            } elseif ($attributeConfig instanceof Name) {
+                $typeName = $attributeConfig->toString();
             }
 
             if ('string' === $typeName) {
-                $attributes[] = u($attributeName)->title()->toString();
+                $attributes[$attributeName] = $factory->val(u($attributeName)->title()->toString());
                 continue;
             } elseif ('int' === $typeName) {
                 static $intAttributes = [];
@@ -85,7 +88,7 @@ class ArgumentGenerator
                 }
 
                 $attribute = $dateTimeImmutableAttributes[$attributeName];
-            } elseif ('Datetime' === $typeName) {
+            } elseif ('DateTime' === $typeName) {
                 static $dateTimeAttributes = [];
                 if (!isset($dateTimeAttributes[$attributeName])) {
                     $value = $dateTimeImmutableAttributes[\count($dateTimeAttributes) - 1] ?? new \DateTime('2021-12-31');
@@ -99,7 +102,7 @@ class ArgumentGenerator
                 $attribute = $dateTimeAttributes[$attributeName];
             }
 
-            $attributes[$attributeName] = $attribute;
+            $attributes[$attributeName] = $attribute instanceof Expr ? $attribute : $factory->val($attribute);
         }
 
         return $attributes;

--- a/tests/Model/Get/Fixture/model_with_get_constructor.php
+++ b/tests/Model/Get/Fixture/model_with_get_constructor.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App;
+
+class ModelWithGetConstructor
+{
+    private string $text;
+
+    public function __construct(string $text)
+    {
+        $this->text = $text;
+    }
+
+    public function getText(): string
+    {
+        return $this->text;
+    }
+}
+
+?>
+---
+<?php
+
+namespace App\Tests\Unit;
+
+use App\ModelWithGetConstructor;
+use PHPUnit\Framework\TestCase;
+
+class ModelWithGetConstructorTest extends TestCase
+{
+    public function testGetText(): void
+    {
+        $model = $this->createInstance(['text' => 'Text']);
+        $this->assertSame('Text', $model->getText());
+        $this->markAsRisky();
+    }
+
+    public function createInstance($data = []): ModelWithGetConstructor
+    {
+        return new ModelWithGetConstructor($data['text'] ?? 'Text');
+    }
+}

--- a/tests/Model/Get/Fixture/model_with_get_constructor_datetime.php
+++ b/tests/Model/Get/Fixture/model_with_get_constructor_datetime.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App;
+
+use DateTime;
+
+class ModelWithGetConstructor
+{
+    private DateTime $dateTime;
+
+    public function __construct(DateTime $dateTime)
+    {
+        $this->dateTime = $dateTime;
+    }
+
+    public function getDateTime(): DateTime
+    {
+        return $this->dateTime;
+    }
+}
+
+?>
+---
+<?php
+
+namespace App\Tests\Unit;
+
+use App\ModelWithGetConstructor;
+use DateTime;
+use PHPUnit\Framework\TestCase;
+
+class ModelWithGetConstructorTest extends TestCase
+{
+    public function testGetDateTime(): void
+    {
+        $dateTime = new DateTime('2022-01-01');
+        $model = $this->createInstance(['dateTime' => $dateTime]);
+        $this->assertSame($dateTime, $model->getDateTime());
+        $this->markAsRisky();
+    }
+
+    public function createInstance($data = []): ModelWithGetConstructor
+    {
+        return new ModelWithGetConstructor($data['dateTime'] ?? new DateTime('2022-01-01'));
+    }
+}

--- a/tests/Model/Get/Fixture/model_with_get_without_constructor.php
+++ b/tests/Model/Get/Fixture/model_with_get_without_constructor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App;
+
+class ModelWithGetWithoutConstructor
+{
+    private int $id;
+
+    public function __construct()
+    {}
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}
+
+?>
+---
+<?php
+
+namespace App\Tests\Unit;
+
+use App\ModelWithGetWithoutConstructor;
+use PHPUnit\Framework\TestCase;
+
+class ModelWithGetWithoutConstructorTest extends TestCase
+{
+    public function testGetId(): void
+    {
+        $model = $this->createInstance();
+        $this->assertSame('TODO', $model->getId());
+        $this->markAsRisky();
+    }
+
+    public function createInstance(): ModelWithGetWithoutConstructor
+    {
+        return new ModelWithGetWithoutConstructor();
+    }
+}

--- a/tests/Model/Get/GetTest.php
+++ b/tests/Model/Get/GetTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Schranz\TestGenerator\Tests\Model\Constructor;
+
+use Schranz\TestGenerator\Tests\AbstractTestCase;
+
+class GetTest extends AbstractTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function testFixtures(\SplFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return \Generator<\SplFileInfo>
+     */
+    public function provideData(): \Generator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+}

--- a/tests/Model/SetGet/Fixture/model_with_set_get_datetime.php
+++ b/tests/Model/SetGet/Fixture/model_with_set_get_datetime.php
@@ -6,12 +6,12 @@ class ModelWithSetGetBirthday
 {
     private \DateTime $birthday;
 
-    public function setBirthday(\Datetime $birthday): void
+    public function setBirthday(\DateTime $birthday): void
     {
         $this->birthday = $birthday;
     }
 
-    public function getBirthday(): \Datetime
+    public function getBirthday(): \DateTime
     {
         return $this->birthday;
     }

--- a/tests/Model/SetGet/Fixture/model_with_set_get_datetime_nullable.php
+++ b/tests/Model/SetGet/Fixture/model_with_set_get_datetime_nullable.php
@@ -6,12 +6,12 @@ class ModelWithSetGetBirthday
 {
     private ?\DateTime $birthday;
 
-    public function setBirthday(?\Datetime $birthday): void
+    public function setBirthday(?\DateTime $birthday): void
     {
         $this->birthday = $birthday;
     }
 
-    public function getBirthday(): ?\Datetime
+    public function getBirthday(): ?\DateTime
     {
         return $this->birthday;
     }


### PR DESCRIPTION
This adds implementation for basic getter tests. Getter tests are test without a setter and need inject the parameter over constructor or manual adoption is required to set the value e.g.: using reflection. Currently the library will not provide a PrivatePropertyTrait to set getter value. 